### PR TITLE
Add ability to tag a commit and other refactorings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'octokit', '~> 4.0'
-gem 'git', '~> 1.2'
+gem 'octokit', '~> 4.6'
 
 group :development do
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.8)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)
-    faraday (0.9.2)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
-    git (1.2.9.1)
     multipart-post (2.0.0)
-    octokit (4.1.1)
-      sawyer (~> 0.6.0, >= 0.5.3)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
     parser (2.3.3.0)
       ast (~> 2.2)
     powerpack (0.1.1)
+    public_suffix (2.0.4)
     rainbow (2.1.0)
     rubocop (0.46.0)
       parser (>= 2.3.1.1, < 3.0)
@@ -20,17 +21,16 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    sawyer (0.6.0)
-      addressable (~> 2.3.5)
-      faraday (~> 0.8, < 0.10)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     unicode-display_width (1.1.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  git (~> 1.2)
-  octokit (~> 4.0)
+  octokit (~> 4.6)
   rubocop
 
 BUNDLED WITH

--- a/gh_release_commenter.rb
+++ b/gh_release_commenter.rb
@@ -10,11 +10,11 @@ def usage
   <<-USAGE.gsub(/^ {4}/, '')
   #{$0} - gathers a list of merged pull requests since some target branch or sha, and makes a comment on each
 
-    Usage: ruby #{$0} -r <user/repo> -t <remote/branch or sha> -c <some comment>
+    Usage: ruby #{$0} -r <user/repo> -t <sha> -c <some comment>
 
     Options:
       -r, --repo:     Github <user/repo> that contains code being deployed.
-      -t, --target:   Github <remote/branch or sha> that contains currently deployed code.
+      -t, --target:   Github <sha> of commit that is the starting point for searching for merge commits.
       -c, --comment:  The comment you would like to post.
   USAGE
 end

--- a/gh_release_commenter.rb
+++ b/gh_release_commenter.rb
@@ -38,13 +38,13 @@ def main(args)
   end
   parser.parse(args)
 
-  unless options[:repo] && options[:comment_sha] && options[:comment]
+  if (options[:repo].nil? || options[:repo].empty?) || (options[:comment_sha].nil? || options[:comment_sha].empty?) || (options[:comment].nil? || options[:comment].empty?)
     puts "  ERROR: --repo, --comment_sha, and --comment are required!"
     $stderr.puts usage
     Process::exit(1)
   end
 
-  if (options[:tag] && !options[:tag_sha]) || (!options[:tag] && options[:tag_sha])
+  if (!options[:tag].nil? && (options[:tag_sha].nil? || options[:tag_sha].empty?)) || ((options[:tag].nil? || options[:tag].empty?) && !options[:tag_sha].nil?)
     puts "  ERROR: --tag and --tag_sha must both be set!"
     $stderr.puts usage
     Process::exit(1)
@@ -64,7 +64,7 @@ def main(args)
   puts "Leaving comment '#{options[:comment]}' on pull requests: #{pr_nums.join(', ')}"
   PullRequestCommenter.new(octokit_client, options[:repo]).add_comment_to_issues(pr_nums, options[:comment])
 
-  if options[:tag] && options[:tag_sha] && !options[:tag].empty? && !options[:tag_sha].empty?
+  if options[:tag] && options[:tag_sha]
     puts "Tagging commit #{options[:tag_sha]}"
     CommitTagger.new(octokit_client, options[:repo]).add_tag_to_commit(options[:tag], options[:tag_sha])
   end

--- a/gh_release_commenter.rb
+++ b/gh_release_commenter.rb
@@ -64,7 +64,7 @@ def main(args)
   puts "Leaving comment '#{options[:comment]}' on pull requests: #{pr_nums.join(', ')}"
   PullRequestCommenter.new(octokit_client, options[:repo]).add_comment_to_issues(pr_nums, options[:comment])
 
-  if options[:tag] && options[:tag_sha]
+  if options[:tag] && options[:tag_sha] && !options[:tag].empty? && !options[:tag_sha].empty?
     puts "Tagging commit #{options[:tag_sha]}"
     CommitTagger.new(octokit_client, options[:repo]).add_tag_to_commit(options[:tag], options[:tag_sha])
   end

--- a/gh_release_commenter.rb
+++ b/gh_release_commenter.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'octokit'
-require_relative 'lib/merged_pull_request_finder'
+require_relative 'lib/pull_request_finder'
 require_relative 'lib/pull_request_commenter'
 
 GITHUB_TOKEN = ENV['GITHUB_TOKEN']
@@ -37,13 +37,15 @@ def main(args)
     Process::exit(1)
   end
 
+  # regex for finding merged pull requests
+  merged_pr_regex = /Merge pull request #(\d*)/i
+
   # setup octokit client
   octokit_client = Octokit::Client.new(:access_token => GITHUB_TOKEN)
 
   # get list of PRs
   puts "Retrieving list of Pull Requests that have been merged since #{options[:target]}"
-  pr_nums = []
-  pr_nums = MergedPullRequestFinder.new(octokit_client, options[:repo].to_s, options[:target].to_s).merged_pr_numbers
+  pr_nums = PullRequestFinder.new(octokit_client, options[:repo].to_s, options[:target].to_s, merged_pr_regex).pr_numbers
 
   # comment on PRs
   puts "Leaving comment on each Pull Request"

--- a/gh_release_commenter.rb
+++ b/gh_release_commenter.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'git'
 require 'octokit'
 require_relative 'lib/merged_pull_request_finder'
 require_relative 'lib/pull_request_commenter'
@@ -44,16 +43,16 @@ def main(args)
     Process::exit(1)
   end
 
+  # setup octokit client
+  octokit_client = Octokit::Client.new(:access_token => GITHUB_TOKEN)
+
   # get list of PRs
   puts "Retrieving list of Pull Requests that have been merged"
-  repo = Git.open(options[:dir].to_s)
   pr_nums = []
-  pr_nums = MergedPullRequestFinder.new(repo, options[:target].to_s).merged_pr_numbers
-
+  pr_nums = MergedPullRequestFinder.new(octokit_client, options[:repo].to_s, options[:target].to_s).merged_pr_numbers
 
   # comment on PRs
   puts "Leaving comment on each Pull Request"
-  octokit_client = Octokit::Client.new(:access_token => GITHUB_TOKEN)
   PullRequestCommenter.new(octokit_client, options[:repo]).add_comment_to_issues(pr_nums, options[:comment])
 end
 

--- a/gh_release_commenter.rb
+++ b/gh_release_commenter.rb
@@ -39,18 +39,19 @@ def main(args)
   parser.parse(args)
 
   unless options[:repo] && options[:comment_sha] && options[:comment]
+    puts "  ERROR: --repo, --comment_sha, and --comment are required!"
     $stderr.puts usage
     Process::exit(1)
   end
 
   if (options[:tag] && !options[:tag_sha]) || (!options[:tag] && options[:tag_sha])
-    puts "  ERROR: --tag and --tag_sha must both be set"
+    puts "  ERROR: --tag and --tag_sha must both be set!"
     $stderr.puts usage
     Process::exit(1)
   end
 
   if options[:tag] =~ /\s/
-    puts "  ERROR: --tag may not contain spaces"
+    puts "  ERROR: --tag may not contain spaces!"
     $stderr.puts usage
     Process::exit(1)
   end

--- a/lib/commit_tagger.rb
+++ b/lib/commit_tagger.rb
@@ -1,19 +1,10 @@
 class CommitTagger
-  def initialize(octokit_client, repo_name, branch)
+  def initialize(octokit_client, repo_name)
     @client = octokit_client
     @repo = repo_name
-    @branch = branch
   end
 
-  def add_tag_to_commit(tag_name)
-    @client.create_ref(@repo, "tags/#{tag_name}", commit_to_tag)
-  end
-
-  private
-
-  def commit_to_tag
-    # TODO gets SHA of parent commit of rc to master merge commit
-    # too specific to our process, add_tag_to_commit should just take a sha
-    @client.commits(@repo, @branch).first.parents.last.sha
+  def add_tag_to_commit(tag_name, commit_sha)
+    @client.create_ref(@repo, "tags/#{tag_name}", commit_sha)
   end
 end

--- a/lib/commit_tagger.rb
+++ b/lib/commit_tagger.rb
@@ -12,7 +12,8 @@ class CommitTagger
   private
 
   def commit_to_tag
-    # get SHA of parent commit of rc to master merge commit
+    # TODO gets SHA of parent commit of rc to master merge commit
+    # too specific to our process, add_tag_to_commit should just take a sha
     @client.commits(@repo, @branch).first.parents.last.sha
   end
 end

--- a/lib/commit_tagger.rb
+++ b/lib/commit_tagger.rb
@@ -1,0 +1,18 @@
+class CommitTagger
+  def initialize(octokit_client, repo_name, branch)
+    @client = octokit_client
+    @repo = repo_name
+    @branch = branch
+  end
+
+  def add_tag_to_commit(tag_name)
+    @client.create_ref(@repo, "tags/#{tag_name}", commit_to_tag)
+  end
+
+  private
+
+  def commit_to_tag
+    # get SHA of parent commit of rc to master merge commit
+    @client.commits(@repo, @branch).first.parents.last.sha
+  end
+end

--- a/lib/merged_pull_request_finder.rb
+++ b/lib/merged_pull_request_finder.rb
@@ -2,32 +2,32 @@ class MergedPullRequestFinder
   MERGED_PR_MESSAGE="Merge pull request #"
   MERGED_PR_REGEX=/Merge pull request #(\d*)/i
 
-  def initialize(repo, last_deploy)
+  def initialize(repo, target)
     @repo = repo
-    @target = last_deploy
+    @target = target
   end
 
   def merged_pr_numbers
-    @merge_commits = merge_commits_since_last_deploy
-    @commit_messages = commit_messages
+    merge_commits_since_target
+    commit_messages
     pr_numbers
   end
 
   private
 
-  def merge_commits_since_last_deploy
-    puts "Diffing git log, searching for commits with '#{MERGED_PR_MESSAGE}'"
-    @repo.log.between(@target).grep(MERGED_PR_MESSAGE)
+  def merge_commits_since_target
+    puts "Diffing git log, searching for commit messages containing '#{MERGED_PR_MESSAGE}'"
+    @merge_commits = @repo.log.between(@target).grep(MERGED_PR_MESSAGE)
   end
 
   def commit_messages
-    @merge_commits.map do |c|
+    @commit_messages = @merge_commits.map do |c|
       c.message
     end
   end
 
   def pr_numbers
-    puts "Getting array of PR numbers from messages in list of commits"
+    puts "Getting PR numbers from commit messages"
     @commit_messages.map do |m|
       m.scan(MERGED_PR_REGEX)
     end.flatten.uniq

--- a/lib/merged_pull_request_finder.rb
+++ b/lib/merged_pull_request_finder.rb
@@ -1,35 +1,41 @@
 class MergedPullRequestFinder
-  MERGED_PR_MESSAGE="Merge pull request #"
   MERGED_PR_REGEX=/Merge pull request #(\d*)/i
 
-  def initialize(repo, target)
-    @repo = repo
-    @target = target
+  def initialize(octokit_client, repo_name, target_sha)
+    @client = octokit_client
+    @repo = repo_name
+    @target = target_sha
   end
 
   def merged_pr_numbers
-    merge_commits_since_target
-    commit_messages
-    pr_numbers
+    puts "Getting PR numbers from commit messages"
+
+    merge_commit_messages_since_target.map do |m|
+      m.scan(MERGED_PR_REGEX)
+    end
+      .flatten
+      .uniq
   end
 
   private
 
-  def merge_commits_since_target
-    puts "Diffing git log, searching for commit messages containing '#{MERGED_PR_MESSAGE}'"
-    @merge_commits = @repo.log.between(@target).grep(MERGED_PR_MESSAGE)
+  def merge_commit_messages_since_target
+    commits_since_target
+      .map { |c| c.commit.message }
+      .grep(MERGED_PR_REGEX)
   end
 
-  def commit_messages
-    @commit_messages = @merge_commits.map do |c|
-      c.message
-    end
+  def commits_since_target
+    commits = @client.commits_since(@repo, target_date)
+    commits.pop  # Because the last commit has likely already been commented on
+    commits
   end
 
-  def pr_numbers
-    puts "Getting PR numbers from commit messages"
-    @commit_messages.map do |m|
-      m.scan(MERGED_PR_REGEX)
-    end.flatten.uniq
+  def target_date
+    @client
+      .commit(@repo, @target)
+      .commit
+      .committer
+      .date
   end
 end

--- a/lib/pull_request_finder.rb
+++ b/lib/pull_request_finder.rb
@@ -1,17 +1,17 @@
-class MergedPullRequestFinder
-  MERGED_PR_REGEX=/Merge pull request #(\d*)/i
+class PullRequestFinder
 
-  def initialize(octokit_client, repo_name, target_sha)
+  def initialize(octokit_client, repo_name, target_sha, search_regex)
     @client = octokit_client
     @repo = repo_name
     @target = target_sha
+    @regex = search_regex
   end
 
-  def merged_pr_numbers
+  def pr_numbers
     puts "Getting PR numbers from commit messages"
 
-    merge_commit_messages_since_target.map do |m|
-      m.scan(MERGED_PR_REGEX)
+    matching_commit_messages_since_target.map do |m|
+      m.scan(@regex)
     end
       .flatten
       .uniq
@@ -19,10 +19,10 @@ class MergedPullRequestFinder
 
   private
 
-  def merge_commit_messages_since_target
+  def matching_commit_messages_since_target
     commits_since_target
       .map { |c| c.commit.message }
-      .grep(MERGED_PR_REGEX)
+      .grep(@regex)
   end
 
   def commits_since_target

--- a/lib/pull_request_finder.rb
+++ b/lib/pull_request_finder.rb
@@ -1,5 +1,4 @@
 class PullRequestFinder
-
   def initialize(octokit_client, repo_name, target_sha, search_regex)
     @client = octokit_client
     @repo = repo_name

--- a/lib/pull_request_finder.rb
+++ b/lib/pull_request_finder.rb
@@ -7,8 +7,6 @@ class PullRequestFinder
   end
 
   def pr_numbers
-    puts "Getting PR numbers from commit messages"
-
     matching_commit_messages_since_target.map do |m|
       m.scan(@regex)
     end


### PR DESCRIPTION
This refactors out the need for the git gem, cleans up some of the existing code, adds the ability to tag a commit, and updates the CLI params to support all this.